### PR TITLE
Fix : Copyright year bug 

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,8 +1,13 @@
 const Footer = () => {
+  const today = new Date();
+  const year = today.getFullYear();
   return (
     <footer className="bg-gray-400 rounded-md bg-clip-padding backdrop-filter backdrop-blur-sm bg-opacity-10 p-5 w-full text-left mt-16">
-      <p className="text-lg">&copy; 2024 Animate Hub. All rights reserved.</p>
+      <p className="text-lg">
+        &copy; {year} Animate Hub. All rights reserved.
+      </p>
     </footer>
   );
 };
+
 export default Footer;


### PR DESCRIPTION
Fixed the copyright year bug now it will fetch the current year rather than diplaying direct copy paste of year text.

closes #124 

I am working under VSOC , 

Email id - meetofficialhere@gmail.com

![Ani](https://github.com/user-attachments/assets/097cf2ad-c8f8-4551-9447-52938932ae44)
