### PR TITLE
Fix Button Redirection for "Become a Contributor" and "Submit a Template"

### DIFF
--- a/src/components/Home/HomePage.jsx
+++ b/src/components/Home/HomePage.jsx
@@ -299,7 +299,7 @@ const HomePage = () => {
               </motion.button>
             </Link>
             <a
-              href="https://github.com/your-repo"
+              href="https://github.com/Premkolte/AnimateHub"
               className="bg-black text-white px-6 py-3 rounded-full text-lg font-semibold shadow-lg"
             >
               <BsPeople className="inline-block mr-2" />
@@ -323,7 +323,7 @@ const HomePage = () => {
               </motion.button>
             </Link>
             <a
-              href="https://github.com/your-repo"
+              href="https://github.com/Premkolte/AnimateHub/issues/new/choose"
               className="bg-black text-white px-6 py-3 rounded-full text-lg font-semibold shadow-lg"
             >
               <LuLayoutTemplate className="inline-block mr-2" />


### PR DESCRIPTION
**Description:**

This PR fixes the redirection issues for the "Become a Contributor" and "Submit a Template" buttons on the website.

**Changes:**

- Updated the "Become a Contributor" button to redirect to the GitHub repository link: [GitHub Repo](https://github.com/Premkolte/AnimateHub).
- Updated the "Submit a Template" button to redirect to the "Create an Issue" page on the GitHub repository: [Create an Issue](https://github.com/Premkolte/AnimateHub/issues/new/choose).

**Checklist:**

- [x] The "Become a Contributor" button now redirects to the GitHub repository.
- [x] The "Submit a Template" button now redirects to the "Create an Issue" page on GitHub.

**Additional Information:**

This fix ensures that users are properly redirected to the appropriate GitHub pages, improving the user experience.