### PR TITLE
Added light mode theme support for Contact Us and About Us

### DIFF
--- a/src/assets/FAQ.jsx
+++ b/src/assets/FAQ.jsx
@@ -1,96 +1,91 @@
 import React, { useState } from 'react';
 
 const Item = ({ title, children }) => {
-    const [isOpen, setIsOpen] = useState(false);
-  
-    return (
-      <div className="border-b">
-        <button
-          type="button"
-          aria-label="Open item"
-          title="Open item"
-          className="flex items-center justify-between w-full p-4 focus:outline-none"
-          onClick={() => setIsOpen(!isOpen)}
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="border-b border-gray-300 dark:border-gray-600">
+      <button
+        type="button"
+        aria-label="Open item"
+        title="Open item"
+        className="flex items-center justify-between w-full p-4 focus:outline-none"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <p className="text-lg font-medium text-black dark:text-white">{title}</p>
+        <svg
+          viewBox="0 0 24 24"
+          className={`w-3 transform transition-transform duration-200 text-black dark:text-white ${
+            isOpen ? 'rotate-180' : ''
+          }`}
         >
-          <p className="text-lg font-medium">{title}</p>
-          <svg
-            viewBox="0 0 24 24"
-            className={`w-3 text-gray-200 transform transition-transform duration-200 ${
-              isOpen ? 'rotate-180' : ''
-            }`}
-          >
-            <polyline
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeMiterlimit="10"
-              points="2,7 12,17 22,7"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
-        {isOpen && (
-          <div className="p-4 pt-0">
-            <p className="text-gray-200">{children}</p>
-          </div>
-        )}
-      </div>
-    );
-  };
-  
-  const FAQ = () => {
-    return (
-      <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20 text-gray-200 ">
-        <div className="max-w-xl sm:mx-auto lg:max-w-2xl ">
-          <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12 ">
-            <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight sm:text-4xl md:mx-auto ">
-              <span className="relative inline-block">
-                <svg
-                  viewBox="0 0 52 24"
-                  fill="currentColor"
-                  className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block"
-                >
-                  <defs>
-                    <pattern
-                      id="232db96b-4aa2-422f-9086-5a77996d1df1"
-                      x="0"
-                      y="0"
-                      width=".135"
-                      height=".30"
-                    >
-                      <circle cx="1" cy="1" r=".7" />
-                    </pattern>
-                  </defs>
-                  <rect
-                    fill="url(#232db96b-4aa2-422f-9086-5a77996d1df1)"
-                    width="52"
-                    height="24"
-                  />
-                </svg>
-                <span className="relative">Frequently Asked Questions❔</span>
-              </span>{' '}
-              
-                </h2>
-                <p className="text-base md:text-lg ">
-                Here are some of the most frequently asked questions. If you have a question that is not answered here, please feel free to reach out to us.
-                </p>
-          </div> 
-          <div className="space-y-4">
-            <Item title="What is AnimateHub ?">
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeMiterlimit="10"
+            points="2,7 12,17 22,7"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="p-4 pt-0">
+          <p className="text-black dark:text-white">{children}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FAQ = () => {
+  return (
+    <div className="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20 text-black dark:text-white">
+      <div className="max-w-xl sm:mx-auto lg:max-w-2xl">
+        <div className="max-w-xl mb-10 md:mx-auto sm:text-center lg:max-w-2xl md:mb-12">
+          <h2 className="max-w-lg mb-6 font-sans text-3xl font-bold leading-none tracking-tight sm:text-4xl md:mx-auto text-black dark:text-white">
+            <span className="relative inline-block">
+              <svg
+                viewBox="0 0 52 24"
+                fill="currentColor"
+                className="absolute top-0 left-0 z-0 hidden w-32 -mt-8 -ml-20 lg:w-32 lg:-ml-28 lg:-mt-10 sm:block text-black dark:text-white"
+              >
+                <defs>
+                  <pattern
+                    id="faq-pattern"
+                    x="0"
+                    y="0"
+                    width=".135"
+                    height=".30"
+                  >
+                    <circle cx="1" cy="1" r=".7" />
+                  </pattern>
+                </defs>
+                <rect fill="url(#faq-pattern)" width="52" height="24" />
+              </svg>
+              <span className="relative">Frequently Asked Questions❔</span>
+            </span>
+          </h2>
+          <p className="text-base md:text-lg text-black dark:text-white">
+            Here are some of the most frequently asked questions. If you have a
+            question that is not answered here, please feel free to reach out to us.
+          </p>
+        </div>
+        <div className="space-y-4">
+          <Item title="What is AnimateHub ?">
             Animate Hub is your go-to resource for all things animation in web development. Discover a wide range of code snippets for animations, hovers, and effects, designed to streamline your workflow. Just copy, paste, and watch your projects come to life!
-            </Item>
-            <Item title="Is this Project Open Source?">
-              Yes!, This project is completely open-source...
-            </Item>
-            <Item title="How can I contribute?">
-              All the steps for contributing to this project are mentioned in the README file of the project. You can check it out <a className="text-blue-400" href="https://github.com/Premkolte/AnimateHub">here</a>.
-            </Item>
-          </div>
+          </Item>
+          <Item title="Is this Project Open Source?">
+            Yes! This project is completely open-source...
+          </Item>
+          <Item title="How can I contribute?">
+            All the steps for contributing to this project are mentioned in the README file of the project. You can check it out <a className="text-blue-600 dark:text-blue-400 underline" href="https://github.com/Premkolte/AnimateHub">here</a>.
+          </Item>
         </div>
       </div>
-    );
-  };
-
+    </div>
+  );
+};
 
 export default FAQ;

--- a/src/components/About/AboutUs.jsx
+++ b/src/components/About/AboutUs.jsx
@@ -71,18 +71,18 @@ const About = () => {
 
   return (
     <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="relative flex flex-col items-center justify-center w-screen h-screen overflow-hidden 
-        bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 text-gray-900 
-        dark:bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] 
-        dark:from-indigo-500 dark:via-violet-500 dark:to-fuchsia-500 dark:text-white"
-    >
+  initial={{ opacity: 0 }}
+  animate={{ opacity: 1 }}
+  transition={{ duration: 0.5 }}
+  className="relative flex flex-col items-center justify-center w-full h-screen overflow-hidden
+    bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 text-gray-900 
+    dark:bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] 
+    dark:from-indigo-500 dark:via-violet-500 dark:to-fuchsia-500 dark:text-white"
+>
       <BackButton />
       <Blobs />
 
-      <div className="relative z-10 container mx-auto px-4 md:px-8">
+      <div className="relative z-10 container mx-auto px-4 md:px-8 ">
         <div className="bg-white/40 bg-opacity-80 backdrop-filter backdrop-blur-md border border-gray-200 rounded-lg shadow-lg p-8 md:p-12 lg:w-2/3 xl:w-1/2 mx-auto mt-7 dark:bg-white dark:bg-opacity-20 dark:border-none">
           <h1 className="text-3xl font-bold mb-3">About Us</h1>
           <p className="text-lg mb-4">

--- a/src/components/About/AboutUs.jsx
+++ b/src/components/About/AboutUs.jsx
@@ -8,11 +8,11 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 import BackButton from "../BackButton";
 
-const About = () =>  {
+const About = () => {
   const Blobs = () => (
     <>
       <svg
-        className="absolute top-0 left-0 transform -translate-x-1/2 -translate-y-1/2 opacity-50"
+        className="absolute top-0 left-0 transform -translate-x-1/2 -translate-y-1/2 opacity-30 dark:opacity-50"
         width="600"
         height="600"
         viewBox="0 0 600 600"
@@ -20,8 +20,8 @@ const About = () =>  {
       >
         <g transform="translate(300,300)">
           <motion.path
-            d="M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z"
-            fill="#fff"
+            fill="#e5e7eb"
+            className="dark:fill-white"
             animate={{
               d: [
                 "M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z",
@@ -38,8 +38,9 @@ const About = () =>  {
           />
         </g>
       </svg>
+
       <svg
-        className="absolute bottom-0 right-0 transform translate-x-1/2 translate-y-1/2 opacity-50"
+        className="absolute bottom-0 right-0 transform translate-x-1/2 translate-y-1/2 opacity-30 dark:opacity-50"
         width="600"
         height="600"
         viewBox="0 0 600 600"
@@ -47,8 +48,8 @@ const About = () =>  {
       >
         <g transform="translate(300,300)">
           <motion.path
-            d="M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z"
-            fill="#fff"
+            fill="#e5e7eb"
+            className="dark:fill-white"
             animate={{
               d: [
                 "M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z",
@@ -73,15 +74,16 @@ const About = () =>  {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
-      className="relative flex flex-col items-center justify-center w-screen h-screen overflow-hidden bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] from-indigo-500 via-violet-500 to-fuchsia-500"
+      className="relative flex flex-col items-center justify-center w-screen h-screen overflow-hidden 
+        bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 text-gray-900 
+        dark:bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] 
+        dark:from-indigo-500 dark:via-violet-500 dark:to-fuchsia-500 dark:text-white"
     >
       <BackButton />
-
       <Blobs />
 
-      {/* Content */}
-      <div className="relative z-10 container mx-auto px-4 md:px-8 text-white">
-        <div className="bg-white bg-clip-padding backdrop-filter backdrop-blur-sm bg-opacity-20 rounded-lg shadow-lg p-8 md:p-12 lg:w-2/3 xl:w-1/2 mx-auto mt-7">
+      <div className="relative z-10 container mx-auto px-4 md:px-8">
+        <div className="bg-white/40 bg-opacity-80 backdrop-filter backdrop-blur-md border border-gray-200 rounded-lg shadow-lg p-8 md:p-12 lg:w-2/3 xl:w-1/2 mx-auto mt-7 dark:bg-white dark:bg-opacity-20 dark:border-none">
           <h1 className="text-3xl font-bold mb-3">About Us</h1>
           <p className="text-lg mb-4">
             AnimateHub is your ultimate resource for learning and exploring
@@ -99,7 +101,7 @@ const About = () =>  {
             <li>
               <a
                 href="https://twitter.com/animatehub"
-                className="text-indigo-250 hover:underline"
+                className="text-blue-500 hover:underline"
               >
                 <FontAwesomeIcon icon={faTwitter} size="2x" />
               </a>
@@ -107,7 +109,7 @@ const About = () =>  {
             <li>
               <a
                 href="https://facebook.com/animatehub"
-                className="text-indigo-250 hover:underline"
+                className="text-blue-600 hover:underline"
               >
                 <FontAwesomeIcon icon={faFacebook} size="2x" />
               </a>
@@ -115,7 +117,7 @@ const About = () =>  {
             <li>
               <a
                 href="https://linkedin.com/company/animatehub"
-                className="text-indigo-250 hover:underline"
+                className="text-blue-700 hover:underline"
               >
                 <FontAwesomeIcon icon={faLinkedin} size="2x" />
               </a>

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -2,12 +2,13 @@ import { useNavigate } from "react-router-dom";
 
 const BackButton = () => {
   const navigate = useNavigate();
+
   return (
     <button
-      className="bg-violet-200 text-center w-48 rounded-2xl h-14 font-sans text-black text-xl font-semibold group absolute top-5 left-5 z-20"
+      className="bg-blue-200 text-center w-48 rounded-2xl h-14 font-sans text-black text-xl font-semibold group absolute top-5 left-5 z-20 dark:bg-violet-200"
       onClick={() => navigate("/")}
     >
-      <div className="bg-violet-400 rounded-xl h-12 w-1/4 flex items-center justify-center absolute left-1 top-[4px] group-hover:w-[184px] z-10 duration-500">
+      <div className="bg-blue-400 rounded-xl h-12 w-1/4 flex items-center justify-center absolute left-1 top-[4px] group-hover:w-[184px] z-10 duration-500 dark:bg-violet-400">
         <svg
           width="25px"
           height="25px"
@@ -28,4 +29,5 @@ const BackButton = () => {
     </button>
   );
 };
+
 export default BackButton;

--- a/src/components/Contact/ContactUs.jsx
+++ b/src/components/Contact/ContactUs.jsx
@@ -72,7 +72,7 @@ const Contact = () => {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
-      className="relative flex flex-col items-center justify-center overflow-hidden w-screen min-h-screen 
+      className="relative flex flex-col items-center justify-center overflow-hidden w-full min-h-screen 
         bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 text-gray-900 
         dark:bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] 
         dark:from-indigo-500 dark:via-violet-500 dark:to-fuchsia-500 dark:text-white"

--- a/src/components/Contact/ContactUs.jsx
+++ b/src/components/Contact/ContactUs.jsx
@@ -10,7 +10,7 @@ const Contact = () => {
   const Blobs = () => (
     <>
       <svg
-        className="absolute top-0 left-0 transform -translate-x-1/2 -translate-y-1/2 opacity-50"
+        className="absolute top-0 left-0 transform -translate-x-1/2 -translate-y-1/2 opacity-30 dark:opacity-50"
         width="600"
         height="600"
         viewBox="0 0 600 600"
@@ -18,8 +18,8 @@ const Contact = () => {
       >
         <g transform="translate(300,300)">
           <motion.path
-            d="M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z"
-            fill="#fff"
+            fill="#e5e7eb"
+            className="dark:fill-white"
             animate={{
               d: [
                 "M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z",
@@ -36,8 +36,9 @@ const Contact = () => {
           />
         </g>
       </svg>
+
       <svg
-        className="absolute bottom-0 right-0 transform translate-x-1/2 translate-y-1/2 opacity-50"
+        className="absolute bottom-0 right-0 transform translate-x-1/2 translate-y-1/2 opacity-30 dark:opacity-50"
         width="600"
         height="600"
         viewBox="0 0 600 600"
@@ -45,8 +46,8 @@ const Contact = () => {
       >
         <g transform="translate(300,300)">
           <motion.path
-            d="M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z"
-            fill="#fff"
+            fill="#e5e7eb"
+            className="dark:fill-white"
             animate={{
               d: [
                 "M120.5,-132.3C156.6,-109.2,176.1,-54.6,169.7,-4.9C163.2,44.9,130.8,89.7,94.7,124.5C58.6,159.3,18.8,184.1,-34.6,192.9C-88,201.6,-154,194.3,-176.4,155.4C-198.9,116.5,-177.8,46,-157.3,-18.1C-136.8,-82.2,-116.8,-139.9,-78.4,-162.7C-40.1,-185.4,16.6,-173.2,63.2,-153.8C109.8,-134.4,144.4,-108.9,120.5,-132.3Z",
@@ -71,34 +72,31 @@ const Contact = () => {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
-      className="relative flex flex-col items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] from-indigo-500 via-violet-500 to-fuchsia-500"
+      className="relative flex flex-col items-center justify-center overflow-hidden w-screen min-h-screen 
+        bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 text-gray-900 
+        dark:bg-[radial-gradient(circle_at_bottom_left,_var(--tw-gradient-stops))] 
+        dark:from-indigo-500 dark:via-violet-500 dark:to-fuchsia-500 dark:text-white"
     >
-      <div className="my-20">
+      <div className="my-16">
         <FAQ />
       </div>
 
       <BackButton />
       <Blobs />
 
-      {/* Content */}
-      <div className="relative z-10 mx-auto px-4 sm:px-8 md:px-20 text-white mb-16 max-w-4xl">
-        <div className="bg-white bg-clip-padding backdrop-filter backdrop-blur-sm bg-opacity-20 rounded-lg shadow-lg p-8">
+      <div className="relative z-10 mx-auto px-4 sm:px-8 md:px-20 text-black dark:text-white mb-16 max-w-4xl">
+        <div className="bg-white/40 bg-opacity-80 backdrop-filter backdrop-blur-md border border-gray-200 rounded-lg shadow-lg p-8 md:p-12 dark:bg-white dark:bg-opacity-20 dark:border-none">
           <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
           <p className="text-lg mb-4">
-            Got any questions, suggestions, or feedback? We'd love to hear from
-            you!
+            Got any questions, suggestions, or feedback? We'd love to hear from you!
           </p>
           <p className="text-lg mb-10">
-            Reach out to us via email at <strong>contact@animatehub.com</strong>{" "}
-            or fill out the form below:
+            Reach out to us via email at <strong>contact@animatehub.com</strong> or fill out the form below:
           </p>
-         
-          <form >
-       
-          <div className=" p-10 p-md-4 pt-2 pt-md-1 pb-10 pb-md-2 px-4 sm:px-8 md:px-20">
-              <label htmlFor="name" className="sr-only">
-                Your Name
-              </label>
+
+          <form>
+            <div className="p-10 pt-2 pb-10 px-4 sm:px-8 md:px-20">
+              <label htmlFor="name" className="sr-only">Your Name</label>
               <div className="relative">
                 <span className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <FontAwesomeIcon icon={faUser} className="text-gray-500" />
@@ -110,20 +108,16 @@ const Contact = () => {
                   placeholder="Your Name"
                   pattern="[a-zA-Z\s]+"
                   title="Name must only contain letters."
-                  className="form-control border border-gray-300 rounded-md py-2 pl-10 pr-4 bg-gray-100 text-gray-800 w-full w-md-500px"
+                  className="form-control border border-gray-300 rounded-md py-2 pl-10 pr-4 bg-gray-100 text-gray-800 w-full"
                 />
               </div>
             </div>
-            <div className="p-10 p-md-4 pt-2 pt-md-1 pb-10 pb-md-2 pr-md-0 px-4 sm:px-8 md:px-20">
-              <label htmlFor="email" className="sr-only">
-                Your Email
-              </label>
+
+            <div className="p-10 pt-2 pb-10 px-4 sm:px-8 md:px-20">
+              <label htmlFor="email" className="sr-only">Your Email</label>
               <div className="relative">
                 <span className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <FontAwesomeIcon
-                    icon={faEnvelope}
-                    className="text-gray-500"
-                  />
+                  <FontAwesomeIcon icon={faEnvelope} className="text-gray-500" />
                 </span>
                 <input
                   type="email"
@@ -134,33 +128,29 @@ const Contact = () => {
                 />
               </div>
             </div>
-            <div className="p-10 p-md-4 pt-2 pt-md-1 px-4 sm:px-20 md:px-20">
-              <label htmlFor="message" className="sr-only">
-                Your Message
-              </label>
+
+            <div className="p-10 pt-2 px-4 sm:px-20 md:px-20">
+              <label htmlFor="message" className="sr-only">Your Message</label>
               <textarea
                 required
                 id="message"
                 placeholder="Your Message"
                 rows="6"
-                className="form-control border border-gray-300 rounded-md py-2 px-4 bg-gray-100 text-gray-800 w-full "
+                className="form-control border border-gray-300 rounded-md py-2 px-4 bg-gray-100 text-gray-800 w-full"
               ></textarea>
             </div>
-            <div className="p-10 p-md-4 pt-4 pt-md-2 text-center" >
-              <button 
+
+            <div className="p-10 pt-4 text-center">
+              <button
                 type="submit"
-                className="btn btn-primary py-2 px-4 w-full sm:w-auto   rounded-md bg-blue-500 text-white hover:bg-blue-600 transition-colors duration-300"
+                className="btn btn-primary py-2 px-4 w-full sm:w-auto rounded-md bg-blue-500 text-white hover:bg-blue-600 transition-colors duration-300"
               >
-                <FontAwesomeIcon icon={faPaperPlane} className="mr-2" /> Send
-                Message
+                <FontAwesomeIcon icon={faPaperPlane} className="mr-2" /> Send Message
               </button>
-          
             </div>
           </form>
         </div>
       </div>
-      
-     
     </motion.div>
   );
 };


### PR DESCRIPTION
# Pull Request Template

## Description
Added light mode theme support for Contact Us and About Us pages to ensure consistent theme switching across the site.

Fixes #259 

## Screenshots of the fix

<img width="1278" height="679" alt="Screenshot 2025-08-03 at 6 51 00 PM" src="https://github.com/user-attachments/assets/0b4bff9f-ff15-447c-a2c3-a8fcd0e3052b" />
<img width="1279" height="674" alt="Screenshot 2025-08-03 at 6 51 08 PM" src="https://github.com/user-attachments/assets/95dfc1c2-2eed-4790-bb9c-ba1eaccc6ecb" />
<img width="1280" height="678" alt="Screenshot 2025-08-03 at 6 51 15 PM" src="https://github.com/user-attachments/assets/7ad6ddee-b22b-47f6-ad33-0e73f465b33d" />


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Email:
yashita.puri2023@vitstudent.ac.in
