### PR TITLE
fix: Replace BrowserRouter with HashRouter to fix 404 on page refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1757,12 +1757,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Routes, Outlet } from "react-router-dom";
+import { HashRouter as Router, Route, Routes, Outlet } from "react-router-dom";
 import { ThemeProvider } from 'next-themes';
 import { Analytics } from '@vercel/analytics/react';
 import { HelmetProvider } from 'react-helmet-async';


### PR DESCRIPTION
### 🔧 Problem
When navigating to routes like `/explore` and refreshing the page, the app throws a `404 Not Found` error. This is because `BrowserRouter` relies on server-side route handling, which isn’t configured on Vercel.

### ✅ Solution
Replaced `BrowserRouter` with `HashRouter` to enable client-side routing using the hash (`#`) portion of the URL. This avoids direct server requests and fixes the 404 issue.

### 📌 GSSOC 2025
This PR is made under **GSSOC 2025**. Please review and let me know if any changes are required 😊

Fixes #276 
