### PR TITLE
improved the spacing, border, of footer and content area

### DIFF
--- a/src/components/Dashboard/SideBar.jsx
+++ b/src/components/Dashboard/SideBar.jsx
@@ -42,12 +42,13 @@ function SideBar({ activeTab, setActiveTab, filteredButtons, searchQuery }) {
 
       {/* Sidebar */}
       <div
-        className={`fixed inset-y-0 left-0 z-40 bg-white dark:bg-secondary-900 border border-blue-300 dark:border-[#a855f7]
- text-gray-300 shadow-xl rounded-xl transform ${
-          isSidebarOpen ? "translate-x-0" : "-translate-x-full"
-        } transition-transform duration-300 ease-in-out lg:translate-x-0 lg:relative lg:inset-0 lg:z-auto overflow-y-auto`}
-        style={{ maxHeight: "100vh", width: "260px" }}
-      >
+  className={`fixed inset-y-0 left-0 z-40 bg-white dark:bg-secondary-900 border border-blue-300 dark:border-[#a855f7]
+    text-gray-300 shadow-xl rounded-xl transform ${
+      isSidebarOpen ? "translate-x-0" : "-translate-x-full"
+    } transition-transform duration-300 ease-in-out lg:translate-x-0 lg:relative lg:inset-0 lg:z-auto overflow-y-auto`}
+  style={{ maxHeight: "calc(100vh - 35px)", width: "260px", bottom: "35px" }}
+>
+
         <div className="p-4 h-full flex flex-col justify-between bg-white dark:bg-secondary-900">
           <div className="space-y-2 mb-4 pb-4 inline-flex flex-col w-auto min-w-full bg-white dark:bg-secondary-900">
             {buttonsToShow.length > 0 ? (

--- a/src/components/Dashboard/Window.jsx
+++ b/src/components/Dashboard/Window.jsx
@@ -104,7 +104,7 @@ function Window({ activeTab }) {
 </h1>
 
 <div
-  className="bg-[#eff6ff] dark:bg-secondary-800 text-secondary-900 dark:text-white p-6 rounded-xl shadow-[0_0_15px_rgba(0,0,0,0.2)] max-w-4xl mx-auto"
+  className="bg-[#eff6ff] dark:bg-secondary-800 text-secondary-900 dark:text-white p-6 rounded-xl shadow-[0_0_15px_rgba(0,0,0,0.2)] max-w-4xl mx-auto "
 >
         {content[activeTab]}
       </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -103,7 +103,7 @@ const footerLinks = [
 
 const Footer = () => {
   return (
-    <footer className="bg-primary-50 dark:bg-secondary-900 text-secondary-800 dark:text-white pt-16 pb-8 border-t border-gray-200 dark:border-secondary-700">
+    <footer className="bg-primary-50 dark:bg-secondary-900 text-secondary-800 dark:text-white pt-16 pb-8 border-t border-gray-200 dark:border-t-[2px] dark:border-secondary-500">
       <div className="max-w-6xl mx-auto px-4">
         {/* Top Content */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-8 mb-12">

--- a/src/components/SnippetComponents/ButtonSnippets.jsx
+++ b/src/components/SnippetComponents/ButtonSnippets.jsx
@@ -68,7 +68,7 @@ border border-blue-300 dark:border-[#a855f7]
               {() =>
                 handleShowModal(buttonObject.jsxCode, buttonObject.cssCode)
               }
-              > Show CSS
+               Show CSS
             </button>
             <button
               className="w-full text-secondary-900 dark:text-white border border-secondary-300 dark:border-secondary-600 bg-white dark:bg-secondary-700 text-md py-3 px-6 rounded-full shadow-md hover:shadow-lg transition-all duration-200"


### PR DESCRIPTION
# Pull Request Template

## Description

The footer on the Explore page was appearing too close to the main content, making it look overlapped and visually cluttered. This PR addresses the spacing issue to improve readability and layout consistency.

**Changes Made ✅**
- Adjusted spacing between the main content and the footer.  
- Added appropriate padding/margin to prevent overlap.  
- Introduced a subtle border to the footer for better separation.  
- Ensured the layout looks consistent in both light and dark modes.

**Impact 💡**
The Explore page now has a clear visual separation between content and footer, enhancing overall user experience and maintaining design consistency.

Screenshot

Before--
<img width="1898" height="780" alt="image" src="https://github.com/user-attachments/assets/c578a144-c4f3-4bf8-9880-a81545acd7fd" />

After--
<img width="1888" height="766" alt="image" src="https://github.com/user-attachments/assets/b1a9ffa3-bf56-416a-9b99-701ad3091a68" />


Fixes #340 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


## Please mention these details about yourself here.
1) Contributor Name : Ankita Gupta
2) Contributor Email ID : ankitagupta94161@gmail.com
3) Contributor Github Link : https://github.com/Ankita-Gupta2004

regards, <br>
Prem Kolte.
