### PR TITLE
Fixed Navbar Title and Description Colors for Light and Dark Themes

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -91,7 +91,7 @@ py-2 pt-1  sticky top-0 left-0 z-50 border-b border-white/20 shadow-[0px_3px_20p
                 src={Logo}
                 alt="AnimateHub Logo"
               />
-              <span className="font-heading text-2xl md:text-3xl font-bold text-white dark:text-gray-100">
+              <span className="font-heading text-2xl md:text-3xl font-bold text-blue-800 dark:text-white-100">
                 AnimateHub
               </span>
             </Link>


### PR DESCRIPTION
# Pull Request Template

## Description

Updated the AnimateHub Navbar so that the site title and description are fully visible in both light and dark modes. The title and description now appear dark blue in light theme and white in dark theme, ensuring better contrast and readability without affecting other design elements.

Fixes #349 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings


## Please mention these details about yourself here.
1) Contributor Name : Amrutha S G
2) Contributor Email ID : amruthasg5507@gmail.com
3) Contributor Github Link : https://github.com/Amruthatech23 


regards, <br>
Prem Kolte.
