### PR TITLE
move gradient background to main container, add top 3 contributor highlights

### DIFF
--- a/src/Pages/Leaderboard/LeaderBoard.jsx
+++ b/src/Pages/Leaderboard/LeaderBoard.jsx
@@ -85,17 +85,21 @@ export default function LeaderBoard() {
   }, []);
 
   if (loading)
-    return (
-      <div className="absolute inset-0 top-[64px] flex flex-col justify-center items-center bg-white dark:bg-gray-950 z-40">
-        <div
-          className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4"
-          style={{ borderColor: "#581C87", borderTopColor: "#581C87", borderBottomColor: "#581C87" }}
-        ></div>
-        <span className="mt-4 text-xl font-medium text-gray-900 dark:text-gray-100">
-          Loading leaderboard...
-        </span>
-      </div>
-    );
+  return (
+    <div className="absolute inset-0 top-[64px] flex flex-col justify-center items-center z-40
+      bg-gradient-to-br from-blue-400 via-purple-300 to-blue-200
+      dark:from-gray-950 dark:via-gray-700 dark:to-gray-900
+      animate-[gradient_8s_ease_infinite] bg-[length:400%_400%]">
+      <div
+        className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4"
+        style={{ borderColor: "#581C87", borderTopColor: "#581C87", borderBottomColor: "#581C87" }}
+      ></div>
+      <span className="mt-4 text-xl font-medium text-gray-900 dark:text-gray-100">
+        Loading leaderboard...
+      </span>
+    </div>
+  );
+
 
   if (contributors.length === 0)
     return (
@@ -103,61 +107,78 @@ export default function LeaderBoard() {
         No contributors found with PRs labeled <strong>GSSoC'25</strong>.
       </p>
     );
+    
 
   return (
-    <div className="max-w-5xl mx-auto mt-10 p-4">
+  <div
+    className="min-h-screen flex flex-col items-center justify-start
+      bg-gradient-to-br from-blue-400 via-purple-300 to-blue-200
+      dark:from-gray-950 dark:via-gray-700 dark:to-gray-900
+      animate-gradient bg-[length:400%_400%] p-4"
+  >
+    <div className="max-w-5xl w-full">
       <div className="flex justify-center">
-        <h2 className="text-4xl font-bold mt-4 mb-16 bg-gradient-to-r from-pink-500 to-blue-800 bg-clip-text text-transparent border-2 border-gray-300 rounded-full px-6 py-2">
+        <h2 className="text-4xl font-bold mt-4 mb-16 bg-gradient-to-r from-pink-500 to-blue-800 bg-clip-text text-transparent border-2 border-gray-400 rounded-full px-6 py-2">
           AnimateHub GSSoC'25 Leaderboard
         </h2>
       </div>
 
       <div className="space-y-4">
-        {contributors.map((contributor, index) => (
-          <div
-            key={contributor.username}
-            onMouseEnter={() => handleHover(index + 1)}
-            className="flex items-center justify-between p-4 rounded-lg shadow-md bg-white dark:bg-gray-800 hover:shadow-lg transform hover:scale-[1.02] transition duration-300"
-          >
-            <div className="flex items-center gap-4">
-              <span className="text-lg font-semibold w-8 text-center">
-                {index === 0
-                  ? "🥇"
-                  : index === 1
-                  ? "🥈"
-                  : index === 2
-                  ? "🥉"
-                  : index + 1}
-              </span>
+        {contributors.map((contributor, index) => {
+  // Determine top 3 border styles
+  let borderStyles = "";
+  if (index === 0)
+    borderStyles = "border-4 border-orange-400 dark:border-orange-400 shadow-lg";
+  else if (index === 1)
+    borderStyles = "border-4 border-blue-400 dark:border-blue-400 shadow-md";
+  else if (index === 2)
+    borderStyles = "border-4 border-green-400 dark:border-green-400 shadow-md";
 
-              <img
-                src={contributor.avatar}
-                alt={contributor.username}
-                className="w-12 h-12 rounded-full border-2 border-purple-500"
-              />
-              <a
-                href={contributor.profile}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-lg font-semibold hover:underline"
-              >
-                {contributor.username}
-              </a>
-            </div>
-            <div className="text-right">
-              <span className="inline-flex items-center gap-2 bg-gray-100 dark:bg-purple-900/30 px-3 py-1 rounded-full text-sm font-semibold">
-                <span className="bg-gradient-to-r from-pink-500 to-purple-500 bg-clip-text text-transparent">
-                  📌 {contributor.prs} PR
-                </span>
-                <span className="text-gray-500">|</span>
-                <span className="bg-gradient-to-r from-blue-500 to-green-500 bg-clip-text text-transparent">
-                  ⭐ {contributor.points} pts
-                </span>
-              </span>
-            </div>
-          </div>
-        ))}
+  return (
+    <div
+      key={contributor.username}
+      onMouseEnter={() => handleHover(index + 1)}
+      className={`flex items-center justify-between p-4 rounded-lg transition-transform transform hover:scale-[1.02] duration-300
+        bg-white dark:bg-gray-800 hover:shadow-lg ${borderStyles}`}
+    >
+      <div className="flex items-center gap-4">
+        <span className="text-lg font-semibold w-8 text-center">
+          {index === 0 ? "🥇" : index === 1 ? "🥈" : index === 2 ? "🥉" : index + 1}
+        </span>
+
+        <img
+          src={contributor.avatar}
+          alt={contributor.username}
+          className="w-12 h-12 rounded-full border-2 border-purple-500"
+        />
+        <a
+          href={contributor.profile}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-lg font-semibold hover:underline"
+        >
+          {contributor.username}
+        </a>
+      </div>
+      <div className="text-right">
+        <span className="inline-flex items-center gap-2 bg-gray-100 dark:bg-purple-900/30 px-3 py-1 rounded-full text-sm font-semibold">
+          <span className="bg-gradient-to-r from-pink-500 to-purple-500 bg-clip-text text-transparent">
+            📌 {contributor.prs} PR
+          </span>
+          <span className="text-gray-500">|</span>
+          <span className="bg-gradient-to-r from-blue-500 to-green-500 bg-clip-text text-transparent">
+            ⭐ {contributor.points} pts
+          </span>
+        </span>
       </div>
     </div>
   );
+})}
+
+
+      </div>
+    </div>
+  </div>
+);
+
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,6 @@ export default {
         heading: ['Sora', 'sans-serif'], // headings
       },
       colors: {
-        // Light theme colors (blue/white)
         primary: {
           50: '#eff6ff',
           100: '#dbeafe',
@@ -22,7 +21,6 @@ export default {
           800: '#1e40af',
           900: '#1e3a8a',
         },
-        // Dark theme colors (purple/gray)
         secondary: {
           50: '#f8fafc',
           100: '#f1f5f9',
@@ -57,7 +55,16 @@ export default {
         'nav-light': 'rgba(255, 255, 255, 0.3)',
         'nav-dark': 'rgba(88, 28, 135, 0.3)',
       },
+      keyframes: {
+        gradient: {
+          '0%, 100%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+        },
+      },
+      animation: {
+        gradient: 'gradient 3s ease infinite',
+      },
     },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION

# Pull Request Template

## Description

- Moved the animated gradient background from the loading screen to the main leaderboard container, ensuring a consistent, vibrant effect in both light and dark modes.
- Highlighted the top 3 contributors with distinct colored borders and subtle shadows for better visual hierarchy.
- Improved overall leaderboard styling for readability and visual appeal.

---

## ✅ Notes
- Top contributors now stand out immediately without relying solely on emojis.
- Gradient background animates smoothly behind the leaderboard content.

---

Fixes #402 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings


## Please mention these details about yourself here.
1) Contributor Name : Ankita Gupta
2) Contributor Email ID : ankitagupta94161@gmail.com
3) Contributor Github Link : https://github.com/Ankita-Gupta2004

regards, <br>
Prem Kolte.
