### PR TITLE
Fix: Chat widget now adapts to Dark/Light mode theme

### DIFF
--- a/src/components/UI/BackToTop.jsx
+++ b/src/components/UI/BackToTop.jsx
@@ -17,11 +17,13 @@ const BackToTop = () => {
   };
 
   return (
-    <button
-      className={`back-to-top ${visible ? 'visible' : 'hidden'}`}
-      onClick={scrollToTop}
-      aria-label="Back to top"
-    >
+<button
+  className={`back-to-top ${visible ? 'visible' : 'hidden'} 
+    bg-gradient-to-r from-[#3b82f6] to-[#accefbff] 
+    dark:from-purple-600 dark:to-blue-600 text-white font-medium px-4 py-2 rounded-full shadow-lg`}
+  onClick={scrollToTop}
+  aria-label="Back to top"
+>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="40"

--- a/src/components/layout/Chatbot.jsx
+++ b/src/components/layout/Chatbot.jsx
@@ -89,7 +89,7 @@ const Chatbot = () => {
         <motion.button
           whileHover={{ scale: 1.05, y: -2 }}
           whileTap={{ scale: 0.95 }}
-          className="relative bg-gradient-to-r from-purple-600 to-blue-600 text-white p-4 rounded-full shadow-2xl hover:shadow-purple-500/25 transition-all duration-300"
+          className="relative bg-gradient-to-r from-[#3b82f6] to-[#accefbff] dark:from-purple-600 dark:to-blue-600  text-white p-4 rounded-full shadow-2xl hover:shadow-purple-500/25 transition-all duration-300"
           onClick={toggleChatbot}
         >
           <motion.div
@@ -121,7 +121,7 @@ const Chatbot = () => {
             className="fixed bottom-24 right-6 w-80 bg-white/95 backdrop-blur-xl border border-gray-200/50 rounded-2xl shadow-2xl z-50 overflow-hidden"
           >
             {/* Header */}
-            <div className="bg-gradient-to-r from-purple-600 to-blue-600 p-4 text-white">
+            <div className="bg-gradient-to-r from-[#3b82f6] to-[#accefbff] dark:from-purple-600 dark:to-blue-600 p-4">
               <div className="flex justify-between items-center">
                 <div className="flex items-center space-x-3">
                   <div className="w-10 h-10 bg-white/20 rounded-full flex items-center justify-center">
@@ -233,7 +233,7 @@ const Chatbot = () => {
                 <motion.button
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
-                  className="px-4 py-3 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-xl shadow-lg hover:shadow-purple-500/25 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-3 bg-gradient-to-r from-[#3b82f6] to-[#accefbff] dark:from-purple-600 dark:to-blue-600 text-white rounded-xl shadow-lg hover:shadow-purple-500/25 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                   onClick={handleSendMessage}
                   disabled={isTyping || !userMessage.trim()}
                 >


### PR DESCRIPTION


## Description

This PR fixes the issue where the chat widget did not adapt to the website’s Dark/Light Mode.

In Dark Mode, the chat widget previously stayed light.

In Light Mode, it stayed dark.

Now, the widget dynamically adjusts based on the selected theme, ensuring a consistent UI/UX across the site.

Fixes #382

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings


## Contributor Details
1. Contributor Name: Tanishq Tiwari

2. Contributor Email ID: [tanishq.tiwari2812@gmail.com](mailto:tanishq.tiwari2812@gmail.com)

3. Contributor Github Link: [txnishq28](https://github.com/txnishq28)

Regards,
Tanishq Tiwari
