### PR TITLE
[FIX]: #472 Light Mode Toggle Button Blends with Background 

### DIFF
--- a/src/components/UI/DarkModeToggle.jsx
+++ b/src/components/UI/DarkModeToggle.jsx
@@ -10,34 +10,34 @@ const DarkModeToggle = () => {
 
   return (
     <button
-      onClick={toggleTheme}
-      className="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-      aria-label="Toggle dark mode"
+  onClick={toggleTheme}
+  className="rounded-lg p-2 transition-colors group hover:bg-gray-200"
+  aria-label="Toggle dark mode"
+>
+  {theme === 'dark' ? (
+    <svg
+      className="w-5 h-5 transition-colors group-hover:text-[rgb(81,32,130)]"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      {theme === 'dark' ? (
-        <svg
-          className="w-5 h-5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-            fillRule="evenodd"
-            clipRule="evenodd"
-          />
-        </svg>
-      ) : (
-        <svg
-          className="w-5 h-5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-        </svg>
-      )}
-    </button>
+      <path
+        d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+        fillRule="evenodd"
+        clipRule="evenodd"
+      />
+    </svg>
+  ) : (
+    <svg
+      className="w-5 h-5 transition-colors group-hover:fill-blue-500"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  )}
+</button>
   );
 };
 


### PR DESCRIPTION
## Description

This PR fixes the visibility issue of the theme toggle button in both **light and dark modes**.  
Earlier, the button background blended with the navbar similar background, making it hard to notice.  
Now, the button has a distinct background/border in both themes, ensuring clear visibility and accessibility.

Fixes #472 

## Checklist:
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published in downstream modules  
- [x] I have checked my code and corrected any misspellings  

## Contributor Details
1) Contributor Name : Kanishka Panwar  
2) Contributor Email ID : Kanishka03p@gmail.com
3) Contributor Github Link : https://github.com/kanishka-commits  

<img width="234" height="67" alt="Screenshot 2025-08-20 at 11 48 30 PM" src="https://github.com/user-attachments/assets/c05f99af-4413-4592-b3a8-1fedf83f8031" />
<img width="234" height="67" alt="Screenshot 2025-08-20 at 11 48 34 PM" src="https://github.com/user-attachments/assets/42aea8f4-f87f-4bec-8748-d86455f52129" />

https://github.com/user-attachments/assets/277cd649-2d71-442b-8a09-02952cfefa68





