### PR TITLE
Enhanced Approved Components API: Fetch by Username & Error Handling

### DIFF
--- a/backend/src/controllers/components.controller.js
+++ b/backend/src/controllers/components.controller.js
@@ -1,7 +1,9 @@
 import { asyncHandler } from "../utils/asyncHandler.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import { ApiError } from "../utils/ApiError.js";
+
 import Component from "../models/components.model.js";
+import User from "../models/user.model.js";
 
 // Create a new component - only logged in users can create components
 export const createComponent = asyncHandler(async (req, res) => {
@@ -184,7 +186,16 @@ export const deleteComponent = asyncHandler(async (req, res) => {
 
 // User is owner of the component - he can see the approved, pending and rejected components
 export const getApprovedComponentsOfLoggedInUser = asyncHandler(async (req, res) => {
-    const userId = req.user._id;
+    const { username } = req.params;
+    const user = await User.findOne({ username }).select('_id').lean()
+    
+console.log(user)
+
+    if (!user){
+        throw new ApiError(404, "No user found with this username, please refresh the page or try later.")
+    }
+
+    const userId = user._id;
 
     const components = await Component.find({ submittedBy: userId, status: "approved" });
 

--- a/backend/src/routes/profile.route.js
+++ b/backend/src/routes/profile.route.js
@@ -18,7 +18,7 @@ router.patch("/update", updateProfile);
 router.patch("/update/avatar", upload.single("avatar"), updateAvatar);
 
 // Get current user's approved components
-router.get("/approved-components", getApprovedComponentsOfLoggedInUser)
+router.get("/approved-components/:username", getApprovedComponentsOfLoggedInUser)
 
 // Get current user's pending components
 router.get("/pending-components", getPendingComponentsOfLoggedInUser);

--- a/src/Pages/Profile/components/AllComponents.jsx
+++ b/src/Pages/Profile/components/AllComponents.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { axiosInstance } from "../../../utils/axiosInstance";
 import { FiRefreshCw, FiAlertCircle, FiBox } from "react-icons/fi";
+import { useParams } from "react-router-dom";
 
 const ComponentCard = ({ component, index }) => (
   <div className="flex flex-col gap-y-4 bg-white dark:bg-secondary-800 rounded-2xl shadow-sm border border-gray-200 dark:border-secondary-700 p-6 hover:shadow-md transition-shadow duration-200 h-full">
@@ -18,9 +19,9 @@ const ComponentCard = ({ component, index }) => (
       <span className="text-sm text-gray-500 dark:text-gray-400">
         {new Date(component.createdAt).toLocaleDateString()}
       </span>
-      <a 
-        href={component.repoLink} 
-        target="_blank" 
+      <a
+        href={component.repoLink}
+        target="_blank"
         rel="noopener noreferrer"
         className="inline-flex items-center text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors font-medium text-sm"
       >
@@ -38,11 +39,13 @@ export default function AllComponents() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const { username } = useParams()
+
   const fetchAllComponents = async (showLoading = true) => {
     try {
       if (showLoading) setLoading(true);
       setError(null);
-      const { data } = await axiosInstance.get("/profile/approved-components");
+      const { data } = await axiosInstance.get(`/profile/approved-components/${username}`);
       if (data.success) {
         setComponents(data.data || []);
       }


### PR DESCRIPTION
**Hi team 👋**  
This PR improves both backend and frontend workflow for displaying approved components. Previously, only logged-in users could fetch their own approved components. Now, any user's approved components can be retrieved by username, supporting public profiles and admin views.

***

### 🔍 Problem Resolved:
- The previous implementation restricted visibility to a user's approved components—only accessible by the signed-in user.
- There was no error handling for invalid or missing usernames when fetching components.

***

### ✅ What’s Changed:
- Updated backend routes:  
  - Added support for fetching approved components via `/approved-components/:username` (instead of just `/approved-components`).
  - Now, anyone (including admins or public profile viewers) can see approved components for any user by providing the username.
- Frontend updated to use the new route for all public profile and admin scenarios.
- Introduced robust error handling:
  - Proper error is shown if the requested username does not exist or no approved components are found.
  - Ensures reliable and user-friendly feedback.

***

### 🎯 Result / Benefit:
- Enables public viewing and admin review of any user’s approved components.
- Supports richer profile views and moderation workflows.
- More robust and predictable behavior with appropriate error messaging.

***

### 🏷 Labels Requested:
- `gssoc25`
- `level2`
- `bug`