### PR TITLE
Fix: Display correct icons for light and dark modes 

### DIFF
--- a/src/components/UI/DarkModeToggle.jsx
+++ b/src/components/UI/DarkModeToggle.jsx
@@ -32,6 +32,15 @@ const DarkModeToggle = () => {
     >
       {theme === 'dark' ? (
         <svg
+          className="w-5 h-5 transition-colors text-gray-800"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+        </svg>
+      ) : (
+        <svg
           className="w-5 h-5 transition-colors text-yellow-300"
           fill="currentColor"
           viewBox="0 0 20 20"
@@ -42,15 +51,6 @@ const DarkModeToggle = () => {
             fillRule="evenodd"
             clipRule="evenodd"
           />
-        </svg>
-      ) : (
-        <svg
-          className="w-5 h-5 transition-colors text-gray-800"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
         </svg>
       )}
     </button>


### PR DESCRIPTION
# Pull Request Template

## Description

In the _DarkModeToggle.jsx_ file, the svg of dark and light mode were opposite to what they should be. I swapped the svg section of dark and light mode.
You can review this while comparing the changes.

Fixes  #611 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Acknowledgement
Thanks for the opportunity for letting me contribute to this beautiful project, looking forward to more contributions. Thanks.
