### PR TITLE
Fix Excessive Margin/Height in Homepage

### DIFF
--- a/src/Pages/Home/HeroSection.jsx
+++ b/src/Pages/Home/HeroSection.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { FaHeart } from "react-icons/fa";
+import { FaGithub, FaHeart, FaPalette, FaPuzzlePiece, FaStar, FaUsers } from "react-icons/fa";
 import { FaHtml5, FaCss3Alt, FaReact } from "react-icons/fa";
 import { BiLogoTailwindCss } from "react-icons/bi";
 import { BsGithub, BsStarFill } from "react-icons/bs";
@@ -102,7 +102,7 @@ const HeroSection = ({ currentUser }) => {
       </div>
 
       <motion.div 
-        className="text-center max-w-3xl mx-auto px-4 pt-28 pb-20"
+        className="text-center max-w-3xl mx-auto px-4 pt-10 pb-20"
         initial="hidden"
         animate="show"
         variants={container}

--- a/src/Pages/Home/Pricing.jsx
+++ b/src/Pages/Home/Pricing.jsx
@@ -142,7 +142,7 @@ const PricingCard = ({ plan, variants }) => (
 
 const PricingSection = () => {
   return (
-    <section className="w-full py-12 sm:py-16 md:py-20 overflow-hidden">
+    <section className="w-full sm:py-10 md:py-2 overflow-hidden">
       <div className="max-w-7xl mx-auto px-4">
         <motion.div
           initial="hidden"

--- a/src/Pages/Home/TemplatesSection.jsx
+++ b/src/Pages/Home/TemplatesSection.jsx
@@ -54,7 +54,7 @@ const templates = [
 
 const TemplatesSection = () => {
   return (
-    <section className="w-full py-20 overflow-hidden">
+    <section className="w-full py-4 overflow-hidden">
       <motion.div
         className="max-w-7xl mx-auto px-4"
         initial="hidden"

--- a/src/Pages/Home/Testimonial.jsx
+++ b/src/Pages/Home/Testimonial.jsx
@@ -82,7 +82,7 @@ const TestimonialSection = () => {
   const duplicatedTestimonials = [...testimonials, ...testimonials];
 
   return (
-    <section className="w-full py-16 sm:py-20 md:py-24 relative overflow-hidden bg-secondary-50 dark:bg-secondary-900">
+    <section className="w-full py-10 md:py-16 relative overflow-hidden bg-secondary-50 dark:bg-secondary-900">
 
       <div className="relative mx-auto px-4 sm:px-6">
         {/* Heading */}


### PR DESCRIPTION
# Pull Request Template

**Description**
On the homepage, several sections (such as **Testimonials** and **Our Amazing Contributors**) currently have **excessive margins and/or `min-h-screen` applied**, which forces these sections to occupy more vertical space than necessary. This creates large empty areas on the page, breaks the natural flow between sections, and results in a disjointed user experience.

Instead of maintaining a smooth, continuous layout, these sections appear visually disconnected and push other content too far down the page. On smaller screens, the issue becomes even more noticeable, as users must **scroll unnecessarily** to reach the next section.

The homepage should have a **consistent spacing system** that adapts dynamically to content size, ensuring that each section flows naturally into the next without overwhelming whitespace.

Refactoring the layout to remove unnecessary height constraints and margins will create a **cleaner, more balanced, and user-friendly homepage**.

Fixes #669

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings


## Please mention these details about yourself here.
1) Contributor Name : Amogh Kashyap S N
2) Contributor Email ID :
3) Contributor Github Link :

regards, <br>
Prem Kolte.

---

# Images

https://github.com/user-attachments/assets/ea5f98e2-dbdd-42a9-92a4-77d669f9df4b

---

# Requested Tags

### GSSoC25 and LEVEL 2