### PR TITLE
[FIX]: #886 Feature card content not vertically centered when title wraps 

### DIFF
--- a/src/Pages/Home/FeaturesSection.jsx
+++ b/src/Pages/Home/FeaturesSection.jsx
@@ -147,6 +147,7 @@ const FeaturesSection = () => {
             <motion.div
               key={index}
               variants={item}
+              whileTap="tap"
               className="bg-white dark:bg-secondary-900 
                 text-secondary-800 dark:text-white 
                 border border-secondary-200 dark:border-secondary-600 
@@ -154,24 +155,26 @@ const FeaturesSection = () => {
                 hover:shadow-xl
                 transition-all duration-300 ease-in-out
                 max-w-md mx-auto w-full
-                flex flex-col items-center hover:shadow-[0_0_12px_2px_rgba(59,130,246,0.7)]
+                flex flex-col items-center justify-center
+                hover:shadow-[0_0_12px_2px_rgba(59,130,246,0.7)]
                 h-full hover:border-primary-600 dark:hover:border-accent-600
-                transform transition-all duration-700 hover:scale-105 dark:hover:shadow-[0_0_12px_2px_rgba(168,85,247,0.7)]"
-              whileTap="tap"
+                transform transition-all duration-700 hover:scale-105 
+                dark:hover:shadow-[0_0_12px_2px_rgba(168,85,247,0.7)]"
             >
-              <div
-                className="w-20 h-20 flex items-center justify-center rounded-2xl mb-6"
-              >
-                {feature.icon}
+              {/* Wrapper keeps icon + text block vertically centered */}
+              <div className="flex flex-col items-center justify-center flex-1">
+                <div className="w-20 h-20 flex items-center justify-center rounded-2xl mb-6">
+                  {feature.icon}
+                </div>
+
+                <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-white text-center leading-tight">
+                  {feature.title}
+                </h3>
+
+                <p className="text-secondary-600 dark:text-secondary-300 leading-relaxed text-center">
+                  {feature.description}
+                </p>
               </div>
-
-              <h3 className="text-xl font-bold mb-3 text-secondary-900 dark:text-white">
-                {feature.title}
-              </h3>
-
-              <p className="text-secondary-600 dark:text-secondary-300 leading-relaxed text-center">
-                {feature.description}
-              </p>
             </motion.div>
           ))}
         </motion.div>


### PR DESCRIPTION
## Description

This PR fixes the vertical alignment issue in the feature cards where the icon and title were not centered when the title spanned two lines.

Fixes #886 

<img width="1110" height="688" alt="Screenshot 2025-10-19 at 4 51 25 PM" src="https://github.com/user-attachments/assets/25bddb79-2696-4256-85da-5844d2509e98" />

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published in downstream modules  
- [x] I have checked my code and corrected any misspellings  

## Please mention these details about yourself here.
1) **Contributor Name:** Kanishka Panwar  
2) **Contributor Email ID:** kanishka03p@gmail.com  
3) **Contributor GitHub Link:** [https://github.com/kanishka-commits](https://github.com/kanishka-commits)  

---

