### PR TITLE
[FIX]: #888 Logo overlaps with "Home" link in the navbar 

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -185,7 +185,7 @@ const Navbar = () => {
         <div className="w-full px-4 lg:px-8">
           <div className="w-full flex justify-between items-center">
             {/* Logo Section */}
-            <div className="flex items-center space-x-3 group">
+            <div className="flex items-center space-x-3 group pr-6">
               <Link
                 to="/"
                 className="flex items-center space-x-3 transform transition-transform duration-300 hover:scale-105"
@@ -210,7 +210,7 @@ const Navbar = () => {
                 </span>
               </Link>
             </div>
-
+            
             {/* Desktop Navigation */}
             <div className="hidden xl:flex items-center space-x-1 xl:space-x-2">
               {navLinks.map((item, index) => {


### PR DESCRIPTION
## Description

This PR fixes the issue where the logo overlaps with the navigation links in the navbar.  
The fix adds right padding (`pr-6`) to the logo section to maintain proper spacing.  
<img width="439" height="86" alt="Screenshot 2025-10-19 at 5 27 32 PM" src="https://github.com/user-attachments/assets/846d3edc-bcf8-4e68-a522-8f47d00994da" />



**Additional Notes:**  
- The dark mode toggle and user login section are initially outside the navbar.  
- If desired, they can be moved inside the navbar for better alignment — I can make those changes as well. Just give me the go-ahead.

Fixes #888 

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] Any dependent changes have been merged and published in downstream modules  
- [x] I have checked my code and corrected any misspellings  


1) **Contributor Name:** Kanishka Panwar  
2) **Contributor Email ID:** [kanishka03p@gmail.com]  
3) **Contributor GitHub Link:** [https://github.com/kanishka-commits](https://github.com/kanishka-commits)  

---

